### PR TITLE
Fix/iptables rules

### DIFF
--- a/bin/dokploy-main.sh
+++ b/bin/dokploy-main.sh
@@ -17,21 +17,29 @@ systemctl status sshd
 sed -i 's/#PermitRootLogin prohibit-password/PermitRootLogin yes/' /etc/ssh/sshd_config
 systemctl restart sshd
 
-# Allow Docker Swarm traffic
+# Allow Docker Swarm and other required ports via UFW
 ufw allow 80,443,3000,996,7946,4789,2377/tcp
 ufw allow 7946,4789,2377/udp
 
+# **Update UFW default forward policy to ACCEPT**
+# This ensures that forwarded traffic isn’t dropped before Docker’s rules are applied.
+sed -i 's/DEFAULT_FORWARD_POLICY="DROP"/DEFAULT_FORWARD_POLICY="ACCEPT"/' /etc/default/ufw
+ufw reload
+
+# Allow specific ports at the INPUT chain (if not already allowed)
 iptables -I INPUT 1 -p tcp --dport 2377 -j ACCEPT
 iptables -I INPUT 1 -p udp --dport 7946 -j ACCEPT
 iptables -I INPUT 1 -p tcp --dport 7946 -j ACCEPT
 iptables -I INPUT 1 -p udp --dport 4789 -j ACCEPT
 
-# Reorder FORWARD chain rules:
-# Remove the default REJECT rule (ignore error if not found)
-iptables -D FORWARD -j REJECT --reject-with icmp-host-prohibited || true
-# Append the REJECT rule at the end so that Docker rules can be matched first
-iptables -A FORWARD -j REJECT --reject-with icmp-host-prohibited
+# **Insert a rule in UFW’s after.rules to explicitly allow traffic to port 3000**
+# UFW builds the FORWARD chain using several files. By adding a rule in /etc/ufw/after.rules,
+# we ensure that traffic destined for port 3000 is accepted before any generic REJECT rules.
+if ! grep -q -- "--dport 3000" /etc/ufw/after.rules; then
+    sed -i '/^# End required rules/i -A ufw-after-forward -p tcp --dport 3000 -j ACCEPT' /etc/ufw/after.rules
+fi
 
+# Save current iptables configuration for persistence across reboots
 netfilter-persistent save
 
 # Install Dokploy

--- a/bin/dokploy-main.sh
+++ b/bin/dokploy-main.sh
@@ -17,30 +17,22 @@ systemctl status sshd
 sed -i 's/#PermitRootLogin prohibit-password/PermitRootLogin yes/' /etc/ssh/sshd_config
 systemctl restart sshd
 
-# Allow Docker Swarm and other required ports via UFW
+# Install Dokploy
+curl -sSL https://dokploy.com/install.sh | sh
+
+# Allow Docker Swarm traffic
 ufw allow 80,443,3000,996,7946,4789,2377/tcp
 ufw allow 7946,4789,2377/udp
 
-# **Update UFW default forward policy to ACCEPT**
-# This ensures that forwarded traffic isn’t dropped before Docker’s rules are applied.
-sed -i 's/DEFAULT_FORWARD_POLICY="DROP"/DEFAULT_FORWARD_POLICY="ACCEPT"/' /etc/default/ufw
-ufw reload
-
-# Allow specific ports at the INPUT chain (if not already allowed)
 iptables -I INPUT 1 -p tcp --dport 2377 -j ACCEPT
 iptables -I INPUT 1 -p udp --dport 7946 -j ACCEPT
 iptables -I INPUT 1 -p tcp --dport 7946 -j ACCEPT
 iptables -I INPUT 1 -p udp --dport 4789 -j ACCEPT
 
-# **Insert a rule in UFW’s after.rules to explicitly allow traffic to port 3000**
-# UFW builds the FORWARD chain using several files. By adding a rule in /etc/ufw/after.rules,
-# we ensure that traffic destined for port 3000 is accepted before any generic REJECT rules.
-if ! grep -q -- "--dport 3000" /etc/ufw/after.rules; then
-    sed -i '/^# End required rules/i -A ufw-after-forward -p tcp --dport 3000 -j ACCEPT' /etc/ufw/after.rules
-fi
-
-# Save current iptables configuration for persistence across reboots
 netfilter-persistent save
 
-# Install Dokploy
-curl -sSL https://dokploy.com/install.sh | sh
+# Reorder FORWARD chain rules:
+# Remove the default REJECT rule (ignore error if not found)
+iptables -D FORWARD -j REJECT --reject-with icmp-host-prohibited || true
+# Append the REJECT rule at the end so that Docker rules can be matched first
+iptables -A FORWARD -j REJECT --reject-with icmp-host-prohibited

--- a/bin/dokploy-main.sh
+++ b/bin/dokploy-main.sh
@@ -10,7 +10,7 @@ chmod 600 /root/.ssh/authorized_keys
 echo "ubuntu ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers
 
 # OpenSSH
-apt install openssh-server
+apt install -y openssh-server
 systemctl status sshd
 
 # Permit root login
@@ -18,12 +18,20 @@ sed -i 's/#PermitRootLogin prohibit-password/PermitRootLogin yes/' /etc/ssh/sshd
 systemctl restart sshd
 
 # Allow Docker Swarm traffic
-ufw allow 80,443,3000,996,7946,4789,2377/tcp;
-ufw allow 7946,4789,2377/udp;
+ufw allow 80,443,3000,996,7946,4789,2377/tcp
+ufw allow 7946,4789,2377/udp
+
 iptables -I INPUT 1 -p tcp --dport 2377 -j ACCEPT
 iptables -I INPUT 1 -p udp --dport 7946 -j ACCEPT
 iptables -I INPUT 1 -p tcp --dport 7946 -j ACCEPT
 iptables -I INPUT 1 -p udp --dport 4789 -j ACCEPT
+
+# Reorder FORWARD chain rules:
+# Remove the default REJECT rule (ignore error if not found)
+iptables -D FORWARD -j REJECT --reject-with icmp-host-prohibited || true
+# Append the REJECT rule at the end so that Docker rules can be matched first
+iptables -A FORWARD -j REJECT --reject-with icmp-host-prohibited
+
 netfilter-persistent save
 
 # Install Dokploy

--- a/bin/dokploy-main.sh
+++ b/bin/dokploy-main.sh
@@ -29,10 +29,10 @@ iptables -I INPUT 1 -p udp --dport 7946 -j ACCEPT
 iptables -I INPUT 1 -p tcp --dport 7946 -j ACCEPT
 iptables -I INPUT 1 -p udp --dport 4789 -j ACCEPT
 
-netfilter-persistent save
-
 # Reorder FORWARD chain rules:
 # Remove the default REJECT rule (ignore error if not found)
 iptables -D FORWARD -j REJECT --reject-with icmp-host-prohibited || true
 # Append the REJECT rule at the end so that Docker rules can be matched first
 iptables -A FORWARD -j REJECT --reject-with icmp-host-prohibited
+
+netfilter-persistent save

--- a/bin/dokploy-worker.sh
+++ b/bin/dokploy-worker.sh
@@ -17,10 +17,6 @@ systemctl status sshd
 sed -i 's/#PermitRootLogin prohibit-password/PermitRootLogin yes/' /etc/ssh/sshd_config
 systemctl restart sshd
 
-# Install Docker
-curl -sSL https://get.docker.com | sh
-docker swarm leave --force 2>/dev/null
-
 # Allow Docker Swarm traffic
 ufw allow 80,443,3000,996,7946,4789,2377/tcp
 ufw allow 7946,4789,2377/udp

--- a/bin/dokploy-worker.sh
+++ b/bin/dokploy-worker.sh
@@ -30,10 +30,10 @@ iptables -I INPUT 1 -p udp --dport 7946 -j ACCEPT
 iptables -I INPUT 1 -p tcp --dport 7946 -j ACCEPT
 iptables -I INPUT 1 -p udp --dport 4789 -j ACCEPT
 
-netfilter-persistent save
-
 # Reorder FORWARD chain rules:
 # Remove the default REJECT rule (ignore error if not found)
 iptables -D FORWARD -j REJECT --reject-with icmp-host-prohibited || true
 # Append the REJECT rule at the end so that Docker rules can be matched first
 iptables -A FORWARD -j REJECT --reject-with icmp-host-prohibited
+
+netfilter-persistent save

--- a/bin/dokploy-worker.sh
+++ b/bin/dokploy-worker.sh
@@ -17,30 +17,23 @@ systemctl status sshd
 sed -i 's/#PermitRootLogin prohibit-password/PermitRootLogin yes/' /etc/ssh/sshd_config
 systemctl restart sshd
 
-# Allow Docker Swarm and other required ports via UFW
+# Install Docker
+curl -sSL https://get.docker.com | sh
+docker swarm leave --force 2>/dev/null
+
+# Allow Docker Swarm traffic
 ufw allow 80,443,3000,996,7946,4789,2377/tcp
 ufw allow 7946,4789,2377/udp
 
-# **Update UFW default forward policy to ACCEPT**
-# This ensures that forwarded traffic isn’t dropped before Docker’s rules are applied.
-sed -i 's/DEFAULT_FORWARD_POLICY="DROP"/DEFAULT_FORWARD_POLICY="ACCEPT"/' /etc/default/ufw
-ufw reload
-
-# Allow specific ports at the INPUT chain (if not already allowed)
 iptables -I INPUT 1 -p tcp --dport 2377 -j ACCEPT
 iptables -I INPUT 1 -p udp --dport 7946 -j ACCEPT
 iptables -I INPUT 1 -p tcp --dport 7946 -j ACCEPT
 iptables -I INPUT 1 -p udp --dport 4789 -j ACCEPT
 
-# **Insert a rule in UFW’s after.rules to explicitly allow traffic to port 3000**
-# UFW builds the FORWARD chain using several files. By adding a rule in /etc/ufw/after.rules,
-# we ensure that traffic destined for port 3000 is accepted before any generic REJECT rules.
-if ! grep -q -- "--dport 3000" /etc/ufw/after.rules; then
-    sed -i '/^# End required rules/i -A ufw-after-forward -p tcp --dport 3000 -j ACCEPT' /etc/ufw/after.rules
-fi
-
-# Save current iptables configuration for persistence across reboots
 netfilter-persistent save
 
-# Install Dokploy
-curl -sSL https://dokploy.com/install.sh | sh
+# Reorder FORWARD chain rules:
+# Remove the default REJECT rule (ignore error if not found)
+iptables -D FORWARD -j REJECT --reject-with icmp-host-prohibited || true
+# Append the REJECT rule at the end so that Docker rules can be matched first
+iptables -A FORWARD -j REJECT --reject-with icmp-host-prohibited

--- a/bin/dokploy-worker.sh
+++ b/bin/dokploy-worker.sh
@@ -17,23 +17,30 @@ systemctl status sshd
 sed -i 's/#PermitRootLogin prohibit-password/PermitRootLogin yes/' /etc/ssh/sshd_config
 systemctl restart sshd
 
-# Allow Docker Swarm traffic
+# Allow Docker Swarm and other required ports via UFW
 ufw allow 80,443,3000,996,7946,4789,2377/tcp
 ufw allow 7946,4789,2377/udp
 
+# **Update UFW default forward policy to ACCEPT**
+# This ensures that forwarded traffic isn’t dropped before Docker’s rules are applied.
+sed -i 's/DEFAULT_FORWARD_POLICY="DROP"/DEFAULT_FORWARD_POLICY="ACCEPT"/' /etc/default/ufw
+ufw reload
+
+# Allow specific ports at the INPUT chain (if not already allowed)
 iptables -I INPUT 1 -p tcp --dport 2377 -j ACCEPT
 iptables -I INPUT 1 -p udp --dport 7946 -j ACCEPT
 iptables -I INPUT 1 -p tcp --dport 7946 -j ACCEPT
 iptables -I INPUT 1 -p udp --dport 4789 -j ACCEPT
 
-# Reorder FORWARD chain rules:
-# Remove the default REJECT rule (ignore error if not found)
-iptables -D FORWARD -j REJECT --reject-with icmp-host-prohibited || true
-# Append the REJECT rule at the end so that Docker rules can be matched first
-iptables -A FORWARD -j REJECT --reject-with icmp-host-prohibited
+# **Insert a rule in UFW’s after.rules to explicitly allow traffic to port 3000**
+# UFW builds the FORWARD chain using several files. By adding a rule in /etc/ufw/after.rules,
+# we ensure that traffic destined for port 3000 is accepted before any generic REJECT rules.
+if ! grep -q -- "--dport 3000" /etc/ufw/after.rules; then
+    sed -i '/^# End required rules/i -A ufw-after-forward -p tcp --dport 3000 -j ACCEPT' /etc/ufw/after.rules
+fi
 
+# Save current iptables configuration for persistence across reboots
 netfilter-persistent save
 
-# Install Docker
-curl -sSL https://get.docker.com | sh
-docker swarm leave --force 2>/dev/null
+# Install Dokploy
+curl -sSL https://dokploy.com/install.sh | sh

--- a/bin/dokploy-worker.sh
+++ b/bin/dokploy-worker.sh
@@ -10,7 +10,7 @@ chmod 600 /root/.ssh/authorized_keys
 echo "ubuntu ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers
 
 # OpenSSH
-apt install openssh-server
+apt install -y openssh-server
 systemctl status sshd
 
 # Permit root login
@@ -18,14 +18,22 @@ sed -i 's/#PermitRootLogin prohibit-password/PermitRootLogin yes/' /etc/ssh/sshd
 systemctl restart sshd
 
 # Allow Docker Swarm traffic
-ufw allow 80,443,3000,996,7946,4789,2377/tcp;
-ufw allow 7946,4789,2377/udp;
+ufw allow 80,443,3000,996,7946,4789,2377/tcp
+ufw allow 7946,4789,2377/udp
+
 iptables -I INPUT 1 -p tcp --dport 2377 -j ACCEPT
 iptables -I INPUT 1 -p udp --dport 7946 -j ACCEPT
 iptables -I INPUT 1 -p tcp --dport 7946 -j ACCEPT
 iptables -I INPUT 1 -p udp --dport 4789 -j ACCEPT
+
+# Reorder FORWARD chain rules:
+# Remove the default REJECT rule (ignore error if not found)
+iptables -D FORWARD -j REJECT --reject-with icmp-host-prohibited || true
+# Append the REJECT rule at the end so that Docker rules can be matched first
+iptables -A FORWARD -j REJECT --reject-with icmp-host-prohibited
+
 netfilter-persistent save
 
 # Install Docker
-# curl -sSL https://get.docker.com | sh
-# docker swarm leave --force 2>/dev/null
+curl -sSL https://get.docker.com | sh
+docker swarm leave --force 2>/dev/null


### PR DESCRIPTION
# Improve Firewall Configuration for Docker Swarm

Enhances and simplifies iptables/UFW configuration for Docker Swarm environments.

## Changes
- Enhanced firewall rules for Docker Swarm and Dokploy
- Improved netfilter-persistent save ordering
- Simplified worker node setup
- Removed redundant Docker installation from worker script