### PR TITLE
Security hardening, multi-key SSH, and tooling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,6 @@
 .ssh
 **/node_modules/
 .terraform.lock.hcl
+# Variable values — contain sensitive data (OCIDs, IPs, SSH keys)
+*.tfvars
+*.tfvars.json

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@
 # Variable values — contain sensitive data (OCIDs, IPs, SSH keys)
 *.tfvars
 *.tfvars.json
+AGENTS.md

--- a/.tflint.hcl
+++ b/.tflint.hcl
@@ -1,0 +1,28 @@
+# tflint configuration for dokploy-oci-free
+#
+# Usage:
+#   terraform init        # required before first run (downloads OCI provider schema)
+#   tflint --init         # installs the plugins below
+#   tflint                # runs all checks
+#
+# OCI-specific schema validation (invalid argument names, wrong types, missing
+# required fields, etc.) is handled via provider deep checking, which reads the
+# OCI provider schema downloaded by `terraform init`. No separate OCI plugin is
+# required for this.
+
+config {
+  # Validate resource arguments against the downloaded provider schemas.
+  # Catches OCI-specific issues such as invalid shape names, wrong argument
+  # types, and missing required fields without needing cloud credentials.
+  call_module_type = "local"
+}
+
+# Official Terraform language ruleset — catches deprecated syntax, missing
+# required providers, unused variables, and other language-level issues.
+plugin "terraform" {
+  enabled = true
+  version = "0.10.0"
+  source  = "github.com/terraform-linters/tflint-ruleset-terraform"
+
+  preset = "recommended"
+}

--- a/README.md
+++ b/README.md
@@ -80,7 +80,15 @@ See more info about configuring your cluster on the [Dokploy Cluster Docs](https
 
 Below are the key variables for deployment which are defined in `variables.tf`:
 
--   `ssh_authorized_keys`: Your SSH public key for accessing the instances.
+-   `ssh_authorized_keys`: One or more SSH public keys for accessing the instances. Accepts a list, so multiple keys can be provided for different client machines:
+    ```hcl
+    ssh_authorized_keys = [
+      "ssh-rsa AAAA...key1 laptop",
+      "ssh-rsa AAAA...key2 desktop",
+      "ssh-ed25519 AAAA...key3 workstation",
+    ]
+    ```
+    All keys are written to `/home/ubuntu/.ssh/authorized_keys` on every instance.
 -   `compartment_id`: OCI compartment ID for instance deployment.
 -   `num_worker_instances`: Number of worker instances to deploy for Dokploy.
 -   `availability_domain_main`: Availability domain for the main instance.

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ To begin deploying applications, you need to add servers to your Dokploy cluster
     -   **Server Name**: Give your server a meaningful name.
     -   **IP Address**: Enter the public IP address of the instance. If you’re using private networking, you can enter the private IP address instead.
     -   **SSH Key**: Select the previous created SSH key.
-    -   **Username**: The SSH user for connecting to the server, use `root`.
+    -   **Username**: The SSH user for connecting to the server, use `ubuntu`.
 4.  **Submit**:
     -   After filling out the necessary fields, click "Submit" to add the server.
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ For detailed information about the free tier, visit [OCI Free Tier](https://www.
 Before you begin, ensure you have the following:
 
 -   An Oracle Cloud Infrastructure (OCI) account with Free Tier resources available.
--   An SSH public key for accessing the instances.
+-   One or more SSH public keys for accessing the instances (one per client machine).
 
 ## Servers & Cluster
 
@@ -93,6 +93,7 @@ Below are the key variables for deployment which are defined in `variables.tf`:
 -   `num_worker_instances`: Number of worker instances to deploy for Dokploy.
 -   `availability_domain_main`: Availability domain for the main instance.
 -   `availability_domain_workers`: Availability domains for worker instances.
--   `instance_shape`: Instance shape (e.g., VM.Standard.E2.1.Micro) used for deployment.
--   `memory_in_gbs`: Memory size (GB) per instance.
--   `ocpus`: Number of OCPUs per instance.
+-   `instance_shape`: Instance shape used for deployment. Defaults to `VM.Standard.A1.Flex` (Ampere A1), which is OCI Always Free eligible.
+-   `memory_in_gbs`: Memory size (GB) per instance. To use the full Always Free allocation across all instances, set to `6` with the default of 4 instances (4 × 6 GB = 24 GB total, the Always Free ceiling).
+-   `ocpus`: Number of OCPUs per instance. To use the full Always Free allocation across all instances, set to `1` with the default of 4 instances (4 × 1 OCPU = 4 OCPUs total, the Always Free ceiling).
+-   `admin_cidr`: CIDR block allowed to access the Dokploy admin dashboard on port 3000. Defaults to `0.0.0.0/0` (open) — restrict to your IP before deploying, e.g. `"1.2.3.4/32"`.

--- a/README.md
+++ b/README.md
@@ -39,10 +39,20 @@ Before you begin, ensure you have the following:
 
 To begin deploying applications, you need to add servers to your Dokploy cluster. A server in Dokploy is where your applications will be deployed and managed.
 
+#### Accessing the Dokploy Dashboard
+
+Port 3000 is not exposed to the internet. Access the dashboard securely via an SSH tunnel:
+
+```bash
+ssh -L 3000:localhost:3000 ubuntu@<main-ip>
+```
+
+Then open [http://localhost:3000](http://localhost:3000) in your browser. The tunnel must remain open while you use the dashboard.
+
 #### Steps to Add Servers:
 
 1.  **Login to Dokploy Dashboard**:
-    -   Access the Dokploy dashboard via the main instance's public IP address. You'll need to use the login credentials configured during setup.
+    -   Open the SSH tunnel above, then navigate to [http://localhost:3000](http://localhost:3000).
 1.  **Generate SSH Keys**:
     -   On the left-hand menu, click on "SSH Keys" and add your private and public SSH key to connect your server.
 2.  **Navigate to Servers Section**:
@@ -94,6 +104,5 @@ Below are the key variables for deployment which are defined in `variables.tf`:
 -   `availability_domain_main`: Availability domain for the main instance.
 -   `availability_domain_workers`: Availability domains for worker instances.
 -   `instance_shape`: Instance shape used for deployment. Defaults to `VM.Standard.A1.Flex` (Ampere A1), which is OCI Always Free eligible.
--   `memory_in_gbs`: Memory size (GB) per instance. To use the full Always Free allocation across all instances, set to `6` with the default of 4 instances (4 × 6 GB = 24 GB total, the Always Free ceiling).
--   `ocpus`: Number of OCPUs per instance. To use the full Always Free allocation across all instances, set to `1` with the default of 4 instances (4 × 1 OCPU = 4 OCPUs total, the Always Free ceiling).
--   `admin_cidr`: CIDR block allowed to access the Dokploy admin dashboard on port 3000. Defaults to `0.0.0.0/0` (open) — restrict to your IP before deploying, e.g. `"1.2.3.4/32"`.
+-   `memory_in_gbs`: Memory size (GB) per instance. Defaults to `12` (2 instances × 12 GB = 24 GB total, the Always Free ceiling).
+-   `ocpus`: Number of OCPUs per instance. Defaults to `2` (2 instances × 2 OCPUs = 4 OCPUs total, the Always Free ceiling).

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ For detailed information about the free tier, visit [OCI Free Tier](https://www.
 Before you begin, ensure you have the following:
 
 -   An Oracle Cloud Infrastructure (OCI) account with Free Tier resources available.
--   An SSH public key for accessing the instances.
+-   One or more SSH public keys for accessing the instances (one per client machine).
 
 ## Servers & Cluster
 
@@ -104,7 +104,7 @@ Below are the key variables for deployment which are defined in `variables.tf`:
 -   `num_worker_instances`: Number of worker instances to deploy for Dokploy.
 -   `availability_domain_main`: Availability domain for the main instance.
 -   `availability_domain_workers`: Availability domains for worker instances.
--   `instance_shape`: Instance shape (e.g., VM.Standard.E2.1.Micro) used for deployment.
--   `memory_in_gbs`: Memory size (GB) per instance.
--   `ocpus`: Number of OCPUs per instance.
+-   `instance_shape`: Instance shape used for deployment. Defaults to `VM.Standard.A1.Flex` (Ampere A1), which is OCI Always Free eligible.
+-   `memory_in_gbs`: Memory size (GB) per instance. To use the full Always Free allocation across all instances, set to `6` with the default of 4 instances (4 × 6 GB = 24 GB total, the Always Free ceiling).
+-   `ocpus`: Number of OCPUs per instance. To use the full Always Free allocation across all instances, set to `1` with the default of 4 instances (4 × 1 OCPU = 4 OCPUs total, the Always Free ceiling).
 -   `use_reserved_public_ip`: If `true`, assign reserved (static) public IPs to the main and worker instances instead of ephemeral IPs. Default is `false`. See [Reserved (static) public IPs](#reserved-static-public-ips).

--- a/README.md
+++ b/README.md
@@ -91,7 +91,15 @@ Note: **Reserved** Static IP does not change unless you release it. It stays in 
 
 Below are the key variables for deployment which are defined in `variables.tf`:
 
--   `ssh_authorized_keys`: Your SSH public key for accessing the instances.
+-   `ssh_authorized_keys`: One or more SSH public keys for accessing the instances. Accepts a list, so multiple keys can be provided for different client machines:
+    ```hcl
+    ssh_authorized_keys = [
+      "ssh-rsa AAAA...key1 laptop",
+      "ssh-rsa AAAA...key2 desktop",
+      "ssh-ed25519 AAAA...key3 workstation",
+    ]
+    ```
+    All keys are written to `/home/ubuntu/.ssh/authorized_keys` on every instance.
 -   `compartment_id`: OCI compartment ID for instance deployment.
 -   `num_worker_instances`: Number of worker instances to deploy for Dokploy.
 -   `availability_domain_main`: Availability domain for the main instance.

--- a/README.md
+++ b/README.md
@@ -39,10 +39,20 @@ Before you begin, ensure you have the following:
 
 To begin deploying applications, you need to add servers to your Dokploy cluster. A server in Dokploy is where your applications will be deployed and managed.
 
+#### Accessing the Dokploy Dashboard
+
+Port 3000 is not exposed to the internet. Access the dashboard securely via an SSH tunnel:
+
+```bash
+ssh -L 3000:localhost:3000 ubuntu@<main-ip>
+```
+
+Then open [http://localhost:3000](http://localhost:3000) in your browser. The tunnel must remain open while you use the dashboard.
+
 #### Steps to Add Servers:
 
 1.  **Login to Dokploy Dashboard**:
-    -   Access the Dokploy dashboard via the main instance's public IP address. You'll need to use the login credentials configured during setup.
+    -   Open the SSH tunnel above, then navigate to [http://localhost:3000](http://localhost:3000).
 1.  **Generate SSH Keys**:
     -   On the left-hand menu, click on "SSH Keys" and add your private and public SSH key to connect your server.
 2.  **Navigate to Servers Section**:
@@ -105,6 +115,6 @@ Below are the key variables for deployment which are defined in `variables.tf`:
 -   `availability_domain_main`: Availability domain for the main instance.
 -   `availability_domain_workers`: Availability domains for worker instances.
 -   `instance_shape`: Instance shape used for deployment. Defaults to `VM.Standard.A1.Flex` (Ampere A1), which is OCI Always Free eligible.
--   `memory_in_gbs`: Memory size (GB) per instance. To use the full Always Free allocation across all instances, set to `6` with the default of 4 instances (4 × 6 GB = 24 GB total, the Always Free ceiling).
--   `ocpus`: Number of OCPUs per instance. To use the full Always Free allocation across all instances, set to `1` with the default of 4 instances (4 × 1 OCPU = 4 OCPUs total, the Always Free ceiling).
+-   `memory_in_gbs`: Memory size (GB) per instance. Defaults to `12` (2 instances × 12 GB = 24 GB total, the Always Free ceiling).
+-   `ocpus`: Number of OCPUs per instance. Defaults to `2` (2 instances × 2 OCPUs = 4 OCPUs total, the Always Free ceiling).
 -   `use_reserved_public_ip`: If `true`, assign reserved (static) public IPs to the main and worker instances instead of ephemeral IPs. Default is `false`. See [Reserved (static) public IPs](#reserved-static-public-ips).

--- a/bin/dokploy-main.sh
+++ b/bin/dokploy-main.sh
@@ -1,7 +1,31 @@
 #!/bin/bash
 
-# Install OpenSSH server
-apt install -y openssh-server
+# Disable automatic updates to prevent apt lock being re-acquired mid-install
+systemctl disable --now unattended-upgrades apt-daily.service apt-daily-upgrade.service \
+  apt-daily.timer apt-daily-upgrade.timer 2>/dev/null || true
+
+# Wait for any remaining apt lock to be released
+while fuser /var/lib/dpkg/lock-frontend /var/lib/apt/lists/lock /var/lib/dpkg/lock >/dev/null 2>&1; do
+  sleep 5
+done
+
+# Install dependencies
+apt-get install -y openssh-server ufw iptables-persistent
+
+# Install Docker before running the Dokploy installer so it finds it already present
+DOCKER_INSTALLER="$(mktemp)"
+curl -fsSL https://get.docker.com -o "$DOCKER_INSTALLER"
+chmod 700 "$DOCKER_INSTALLER"
+sh "$DOCKER_INSTALLER"
+rm -f "$DOCKER_INSTALLER"
+systemctl enable docker
+systemctl start docker
+
+# Install ufw-docker to prevent Docker from bypassing UFW rules
+curl -fsSL https://github.com/chaifeng/ufw-docker/raw/master/ufw-docker \
+  -o /usr/local/bin/ufw-docker
+chmod +x /usr/local/bin/ufw-docker
+ufw-docker install
 
 # Install Dokploy
 DOKPLOY_INSTALLER="$(mktemp)"
@@ -11,8 +35,8 @@ bash "$DOKPLOY_INSTALLER"
 rm -f "$DOKPLOY_INSTALLER"
 
 # Allow Docker Swarm traffic
-ufw allow 80,443,996,7946,4789,2377/tcp
-ufw allow 7946,4789,2377/udp
+/usr/sbin/ufw allow 80,443,996,7946,4789,2377/tcp
+/usr/sbin/ufw allow 7946,4789,2377/udp
 
 iptables -I INPUT 1 -p tcp --dport 2377 -j ACCEPT
 iptables -I INPUT 1 -p udp --dport 7946 -j ACCEPT

--- a/bin/dokploy-main.sh
+++ b/bin/dokploy-main.sh
@@ -1,24 +1,14 @@
 #!/bin/bash
 
-# Add ubuntu SSH authorized keys to the root user
-mkdir -p /root/.ssh
-cp /home/ubuntu/.ssh/authorized_keys /root/.ssh/
-chown root:root /root/.ssh/authorized_keys
-chmod 600 /root/.ssh/authorized_keys
-
-# Add ubuntu user to sudoers
-echo "ubuntu ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers
-
-# OpenSSH
+# Install OpenSSH server
 apt install -y openssh-server
-systemctl status sshd
-
-# Permit root login
-sed -i 's/#PermitRootLogin prohibit-password/PermitRootLogin yes/' /etc/ssh/sshd_config
-systemctl restart sshd
 
 # Install Dokploy
-curl -sSL https://dokploy.com/install.sh | sh
+DOKPLOY_INSTALLER="$(mktemp)"
+curl -sSfL https://dokploy.com/install.sh -o "$DOKPLOY_INSTALLER"
+chmod 700 "$DOKPLOY_INSTALLER"
+bash "$DOKPLOY_INSTALLER"
+rm -f "$DOKPLOY_INSTALLER"
 
 # Allow Docker Swarm traffic
 ufw allow 80,443,3000,996,7946,4789,2377/tcp

--- a/bin/dokploy-main.sh
+++ b/bin/dokploy-main.sh
@@ -11,7 +11,7 @@ bash "$DOKPLOY_INSTALLER"
 rm -f "$DOKPLOY_INSTALLER"
 
 # Allow Docker Swarm traffic
-ufw allow 80,443,3000,996,7946,4789,2377/tcp
+ufw allow 80,443,996,7946,4789,2377/tcp
 ufw allow 7946,4789,2377/udp
 
 iptables -I INPUT 1 -p tcp --dport 2377 -j ACCEPT

--- a/bin/dokploy-worker.sh
+++ b/bin/dokploy-worker.sh
@@ -1,21 +1,14 @@
 #!/bin/bash
 
-# Add ubuntu SSH authorized keys to the root user
-mkdir -p /root/.ssh
-cp /home/ubuntu/.ssh/authorized_keys /root/.ssh/
-chown root:root /root/.ssh/authorized_keys
-chmod 600 /root/.ssh/authorized_keys
-
-# Add ubuntu user to sudoers
-echo "ubuntu ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers
-
-# OpenSSH
+# Install OpenSSH server
 apt install -y openssh-server
-systemctl status sshd
 
-# Permit root login
-sed -i 's/#PermitRootLogin prohibit-password/PermitRootLogin yes/' /etc/ssh/sshd_config
-systemctl restart sshd
+# Install Dokploy
+DOKPLOY_INSTALLER="$(mktemp)"
+curl -sSfL https://dokploy.com/install.sh -o "$DOKPLOY_INSTALLER"
+chmod 700 "$DOKPLOY_INSTALLER"
+bash "$DOKPLOY_INSTALLER"
+rm -f "$DOKPLOY_INSTALLER"
 
 # Allow Docker Swarm traffic
 ufw allow 80,443,3000,996,7946,4789,2377/tcp

--- a/bin/dokploy-worker.sh
+++ b/bin/dokploy-worker.sh
@@ -1,7 +1,31 @@
 #!/bin/bash
 
-# Install OpenSSH server
-apt install -y openssh-server
+# Disable automatic updates to prevent apt lock being re-acquired mid-install
+systemctl disable --now unattended-upgrades apt-daily.service apt-daily-upgrade.service \
+  apt-daily.timer apt-daily-upgrade.timer 2>/dev/null || true
+
+# Wait for any remaining apt lock to be released
+while fuser /var/lib/dpkg/lock-frontend /var/lib/apt/lists/lock /var/lib/dpkg/lock >/dev/null 2>&1; do
+  sleep 5
+done
+
+# Install dependencies
+apt-get install -y openssh-server ufw iptables-persistent
+
+# Install Docker before running the Dokploy installer so it finds it already present
+DOCKER_INSTALLER="$(mktemp)"
+curl -fsSL https://get.docker.com -o "$DOCKER_INSTALLER"
+chmod 700 "$DOCKER_INSTALLER"
+sh "$DOCKER_INSTALLER"
+rm -f "$DOCKER_INSTALLER"
+systemctl enable docker
+systemctl start docker
+
+# Install ufw-docker to prevent Docker from bypassing UFW rules
+curl -fsSL https://github.com/chaifeng/ufw-docker/raw/master/ufw-docker \
+  -o /usr/local/bin/ufw-docker
+chmod +x /usr/local/bin/ufw-docker
+ufw-docker install
 
 # Install Dokploy
 DOKPLOY_INSTALLER="$(mktemp)"
@@ -11,8 +35,8 @@ bash "$DOKPLOY_INSTALLER"
 rm -f "$DOKPLOY_INSTALLER"
 
 # Allow Docker Swarm traffic
-ufw allow 80,443,3000,996,7946,4789,2377/tcp
-ufw allow 7946,4789,2377/udp
+/usr/sbin/ufw allow 80,443,996,7946,4789,2377/tcp
+/usr/sbin/ufw allow 7946,4789,2377/udp
 
 iptables -I INPUT 1 -p tcp --dport 2377 -j ACCEPT
 iptables -I INPUT 1 -p udp --dport 7946 -j ACCEPT

--- a/locals.tf
+++ b/locals.tf
@@ -2,7 +2,7 @@
 locals {
   instance_config = {
     is_pv_encryption_in_transit_enabled = true
-    ssh_authorized_keys                 = var.ssh_authorized_keys
+    ssh_authorized_keys                 = join("\n", var.ssh_authorized_keys)
     shape                               = var.instance_shape
     shape_config = {
       memory_in_gbs = var.memory_in_gbs

--- a/locals.tf
+++ b/locals.tf
@@ -16,7 +16,7 @@ locals {
       recovery_action = "RESTORE_INSTANCE"
     }
     instance_options = {
-      are_legacy_imds_endpoints_disabled = false
+      are_legacy_imds_endpoints_disabled = true
     }
   }
 }

--- a/main.tf
+++ b/main.tf
@@ -42,7 +42,7 @@ resource "oci_core_instance" "dokploy_main" {
     is_management_disabled = "false"
     is_monitoring_disabled = "false"
     plugins_config {
-      desired_state = "DISABLED"
+      desired_state = "ENABLED"
       name          = "Vulnerability Scanning"
     }
     plugins_config {
@@ -130,7 +130,7 @@ resource "oci_core_instance" "dokploy_worker" {
     is_management_disabled = "false"
     is_monitoring_disabled = "false"
     plugins_config {
-      desired_state = "DISABLED"
+      desired_state = "ENABLED"
       name          = "Vulnerability Scanning"
     }
     plugins_config {

--- a/network.tf
+++ b/network.tf
@@ -44,17 +44,6 @@ resource "oci_core_security_list" "dokploy_security_list" {
   vcn_id         = oci_core_vcn.dokploy_vcn.id
   display_name   = "Dokploy Security List"
 
-  # Ingress Rules for Dokploy
-  ingress_security_rules {
-    protocol = "6" # TCP
-    source   = var.admin_cidr
-    tcp_options {
-      min = 3000
-      max = 3000
-    }
-    description = "Allow HTTP traffic for Dokploy admin dashboard on port 3000"
-  }
-
   # SSH
   ingress_security_rules {
     protocol = "6" # TCP

--- a/network.tf
+++ b/network.tf
@@ -47,12 +47,12 @@ resource "oci_core_security_list" "dokploy_security_list" {
   # Ingress Rules for Dokploy
   ingress_security_rules {
     protocol = "6" # TCP
-    source   = "0.0.0.0/0"
+    source   = var.admin_cidr
     tcp_options {
       min = 3000
       max = 3000
     }
-    description = "Allow HTTP traffic for Dokploy on port 3000"
+    description = "Allow HTTP traffic for Dokploy admin dashboard on port 3000"
   }
 
   # SSH
@@ -133,55 +133,55 @@ resource "oci_core_security_list" "dokploy_security_list" {
     description = "Allow Traefik HTTPS traffic on port 444"
   }
 
-  # Ingress rules for Docker Swarm
+  # Ingress rules for Docker Swarm (internal VCN only — nodes do not need internet access to these ports)
   ingress_security_rules {
     protocol = "6" # TCP
-    source   = "0.0.0.0/0"
+    source   = "10.0.0.0/16"
     tcp_options {
       min = 2376
       max = 2376
     }
-    description = "Allow Docker Swarm traffic on port 2376"
+    description = "Allow Docker Swarm traffic on port 2376 (internal only)"
   }
 
   ingress_security_rules {
     protocol = "6" # TCP
-    source   = "0.0.0.0/0"
+    source   = "10.0.0.0/16"
     tcp_options {
       min = 2377
       max = 2377
     }
-    description = "Allow Docker Swarm traffic on port 2377"
+    description = "Allow Docker Swarm traffic on port 2377 (internal only)"
   }
 
   ingress_security_rules {
     protocol = "6" # TCP
-    source   = "0.0.0.0/0"
+    source   = "10.0.0.0/16"
     tcp_options {
       min = 7946
       max = 7946
     }
-    description = "Allow Docker Swarm traffic on port 7946"
+    description = "Allow Docker Swarm traffic on port 7946 (internal only)"
   }
 
   ingress_security_rules {
     protocol = "17" # UDP
-    source   = "0.0.0.0/0"
+    source   = "10.0.0.0/16"
     udp_options {
       min = 7946
       max = 7946
     }
-    description = "Allow Docker Swarm UDP traffic on port 7946"
+    description = "Allow Docker Swarm UDP traffic on port 7946 (internal only)"
   }
 
   ingress_security_rules {
     protocol = "17" # UDP
-    source   = "0.0.0.0/0"
+    source   = "10.0.0.0/16"
     udp_options {
       min = 4789
       max = 4789
     }
-    description = "Allow Docker Swarm UDP traffic on port 4789"
+    description = "Allow Docker Swarm VXLAN overlay on port 4789 (internal only)"
   }
 
   # Egress Rule (optional, if needed)

--- a/providers.tf
+++ b/providers.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "~> 1.11"
+  required_version = ">= 1.5"
 
   required_providers {
     oci = {

--- a/providers.tf
+++ b/providers.tf
@@ -1,1 +1,16 @@
+terraform {
+  required_version = "~> 1.11"
+
+  required_providers {
+    oci = {
+      source  = "hashicorp/oci"
+      version = "~> 8.3"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.8"
+    }
+  }
+}
+
 provider "oci" {}

--- a/terraform.tfvars.example
+++ b/terraform.tfvars.example
@@ -1,0 +1,54 @@
+# Dokploy OCI Free Tier — variable values template
+#
+# Copy this file to terraform.tfvars and fill in your values:
+#   cp terraform.tfvars.example terraform.tfvars
+#
+# terraform.tfvars is gitignored and will never be committed.
+
+# ------------------------------------------------------------------------------
+# Required
+# ------------------------------------------------------------------------------
+
+# OCI compartment OCID
+# Find it: OCI Console → Profile (top right) → Tenancy → OCID
+compartment_id = "ocid1.compartment.oc1..aaaaaaaa..."
+
+# Ubuntu 22.04 image OCID for your chosen region
+# Find it: https://docs.oracle.com/en-us/iaas/images/image/128dbc42-65a9-4ed0-a2db-be7aa584c726/index.htm
+source_image_id = "ocid1.image.oc1..aaaaaaaa..."
+
+# Availability domain for the main instance
+# Find it: OCI Console → Compute → Instances → Availability domain (left menu)
+# Example: "WBJv:EU-FRANKFURT-1-AD-1"
+availability_domain_main = ""
+
+# Availability domain for worker instances (use a different AD to the main instance)
+# Example: "WBJv:EU-FRANKFURT-1-AD-2"
+availability_domain_workers = ""
+
+# SSH public keys — one per client machine you want to connect from
+# Get your key: cat ~/.ssh/id_ed25519.pub  (or id_rsa.pub)
+ssh_authorized_keys = [
+  "ssh-ed25519 AAAA... your-machine-name",
+  # "ssh-ed25519 AAAA... another-machine",
+]
+
+# ------------------------------------------------------------------------------
+# Security — important, set before deploying
+# ------------------------------------------------------------------------------
+
+# Restrict the Dokploy admin dashboard (port 3000) to your IP only
+# Find your public IP: curl ifconfig.me
+# Format: "1.2.3.4/32"
+admin_cidr = "0.0.0.0/0"
+
+# ------------------------------------------------------------------------------
+# Optional — defaults match OCI Always Free limits (1 main + 3 workers)
+# ------------------------------------------------------------------------------
+
+# Number of worker instances (max 3 to stay within Always Free: 4 total × 1 OCPU × 6 GB)
+# num_worker_instances = 3
+
+# instance_shape = "VM.Standard.A1.Flex"
+# ocpus          = "1"
+# memory_in_gbs  = "6"

--- a/terraform.tfvars.example
+++ b/terraform.tfvars.example
@@ -43,12 +43,13 @@ ssh_authorized_keys = [
 admin_cidr = "0.0.0.0/0"
 
 # ------------------------------------------------------------------------------
-# Optional — defaults match OCI Always Free limits (1 main + 3 workers)
+# Optional — defaults use 2 × (2 OCPU, 12 GB) layout (1 main + 1 worker)
+# This uses the full Always Free allocation: 4 OCPUs and 24 GB total.
 # ------------------------------------------------------------------------------
 
-# Number of worker instances (max 3 to stay within Always Free: 4 total × 1 OCPU × 6 GB)
-# num_worker_instances = 3
+# Number of worker instances (max 3 to stay within Always Free limits)
+# num_worker_instances = 1
 
 # instance_shape = "VM.Standard.A1.Flex"
-# ocpus          = "1"
-# memory_in_gbs  = "6"
+# ocpus          = "2"
+# memory_in_gbs  = "12"

--- a/terraform.tfvars.example
+++ b/terraform.tfvars.example
@@ -34,15 +34,6 @@ ssh_authorized_keys = [
 ]
 
 # ------------------------------------------------------------------------------
-# Security — important, set before deploying
-# ------------------------------------------------------------------------------
-
-# Restrict the Dokploy admin dashboard (port 3000) to your IP only
-# Find your public IP: curl ifconfig.me
-# Format: "1.2.3.4/32"
-admin_cidr = "0.0.0.0/0"
-
-# ------------------------------------------------------------------------------
 # Optional — defaults use 2 × (2 OCPU, 12 GB) layout (1 main + 1 worker)
 # This uses the full Always Free allocation: 4 OCPUs and 24 GB total.
 # ------------------------------------------------------------------------------

--- a/variables.tf
+++ b/variables.tf
@@ -46,9 +46,3 @@ variable "ocpus" {
   type        = string
   default     = "2" # OCI Free
 }
-
-variable "admin_cidr" {
-  description = "CIDR block allowed to access the Dokploy admin dashboard (port 3000). Restrict this to your IP for better security, e.g. '1.2.3.4/32'. Defaults to open — change before production use."
-  type        = string
-  default     = "0.0.0.0/0"
-}

--- a/variables.tf
+++ b/variables.tf
@@ -46,3 +46,9 @@ variable "ocpus" {
   type        = string
   default     = "1" # OCI Free
 }
+
+variable "admin_cidr" {
+  description = "CIDR block allowed to access the Dokploy admin dashboard (port 3000). Restrict this to your IP for better security, e.g. '1.2.3.4/32'. Defaults to open — change before production use."
+  type        = string
+  default     = "0.0.0.0/0"
+}

--- a/variables.tf
+++ b/variables.tf
@@ -14,9 +14,9 @@ variable "source_image_id" {
 }
 
 variable "num_worker_instances" {
-  description = "Number of Dokploy worker instances to deploy. Max 3 for Always Free tier (3 workers + 1 main = 4 instances, 4 OCPUs, 24 GB total)."
+  description = "Number of Dokploy worker instances to deploy. Max 3 for Always Free tier. Default is 1 (1 main + 1 worker = 2 instances, 4 OCPUs, 24 GB total)."
   type        = number
-  default     = 3
+  default     = 1
 }
 
 variable "availability_domain_main" {
@@ -36,15 +36,15 @@ variable "instance_shape" {
 }
 
 variable "memory_in_gbs" {
-  description = "Memory in GBs per instance. At 6 GB with 4 instances (1 main + 3 workers), total is 24 GB — the Always Free ceiling."
+  description = "Memory in GBs per instance. At 12 GB with 2 instances (1 main + 1 worker), total is 24 GB — the Always Free ceiling."
   type        = string
-  default     = "6" # OCI Free
+  default     = "12" # OCI Free
 }
 
 variable "ocpus" {
-  description = "OCPUs per instance. At 1 OCPU with 4 instances (1 main + 3 workers), total is 4 OCPUs — the Always Free ceiling."
+  description = "OCPUs per instance. At 2 OCPUs with 2 instances (1 main + 1 worker), total is 4 OCPUs — the Always Free ceiling."
   type        = string
-  default     = "1" # OCI Free
+  default     = "2" # OCI Free
 }
 
 variable "admin_cidr" {

--- a/variables.tf
+++ b/variables.tf
@@ -1,6 +1,6 @@
 variable "ssh_authorized_keys" {
-  description = "SSH public key for instances. For example: ssh-rsa AAEAAAA....3R ssh-key-2024-09-03"
-  type        = string
+  description = "One or more SSH public keys for instance access. For example: [\"ssh-rsa AAAA...key1\", \"ssh-rsa AAAA...key2\"]"
+  type        = list(string)
 }
 
 variable "compartment_id" {

--- a/variables.tf
+++ b/variables.tf
@@ -14,9 +14,9 @@ variable "source_image_id" {
 }
 
 variable "num_worker_instances" {
-  description = "Number of Dokploy worker instances to deploy (max 3 for free tier)."
+  description = "Number of Dokploy worker instances to deploy. Max 3 for Always Free tier (3 workers + 1 main = 4 instances, 4 OCPUs, 24 GB total)."
   type        = number
-  default     = 1
+  default     = 3
 }
 
 variable "availability_domain_main" {
@@ -25,7 +25,7 @@ variable "availability_domain_main" {
 }
 
 variable "availability_domain_workers" {
-  description = "Availability domain for dokploy-main instance. Find it Core Infrastructure → Compute → Instances → Availability domain (left menu). For example: WBJv:EU-FRANKFURT-1-AD-2"
+  description = "Availability domain for dokploy-worker instances. Find it Core Infrastructure → Compute → Instances → Availability domain (left menu). For example: WBJv:EU-FRANKFURT-1-AD-2"
   type        = string
 }
 
@@ -36,13 +36,13 @@ variable "instance_shape" {
 }
 
 variable "memory_in_gbs" {
-  description = "Memory in GBs for instance shape config. 6 GB is the maximum for free tier with 3 working nodes."
+  description = "Memory in GBs per instance. At 6 GB with 4 instances (1 main + 3 workers), total is 24 GB — the Always Free ceiling."
   type        = string
   default     = "6" # OCI Free
 }
 
 variable "ocpus" {
-  description = "OCPUs for instance shape config. 1 OCPU is the maximum for free tier with 3 working nodes."
+  description = "OCPUs per instance. At 1 OCPU with 4 instances (1 main + 3 workers), total is 4 OCPUs — the Always Free ceiling."
   type        = string
   default     = "1" # OCI Free
 }

--- a/variables.tf
+++ b/variables.tf
@@ -14,9 +14,9 @@ variable "source_image_id" {
 }
 
 variable "num_worker_instances" {
-  description = "Number of Dokploy worker instances to deploy. Max 3 for Always Free tier (3 workers + 1 main = 4 instances, 4 OCPUs, 24 GB total)."
+  description = "Number of Dokploy worker instances to deploy. Max 3 for Always Free tier. Default is 1 (1 main + 1 worker = 2 instances, 4 OCPUs, 24 GB total)."
   type        = number
-  default     = 3
+  default     = 1
 }
 
 variable "availability_domain_main" {
@@ -36,15 +36,15 @@ variable "instance_shape" {
 }
 
 variable "memory_in_gbs" {
-  description = "Memory in GBs per instance. At 6 GB with 4 instances (1 main + 3 workers), total is 24 GB — the Always Free ceiling."
+  description = "Memory in GBs per instance. At 12 GB with 2 instances (1 main + 1 worker), total is 24 GB — the Always Free ceiling."
   type        = string
-  default     = "6" # OCI Free
+  default     = "12" # OCI Free
 }
 
 variable "ocpus" {
-  description = "OCPUs per instance. At 1 OCPU with 4 instances (1 main + 3 workers), total is 4 OCPUs — the Always Free ceiling."
+  description = "OCPUs per instance. At 2 OCPUs with 2 instances (1 main + 1 worker), total is 4 OCPUs — the Always Free ceiling."
   type        = string
-  default     = "1" # OCI Free
+  default     = "2" # OCI Free
 }
 
 variable "use_reserved_public_ip" {


### PR DESCRIPTION
## Summary

- **Security hardening**: Fix critical and high severity vulnerabilities — removes root SSH login, passwordless sudo, and `curl|sh` installer; restricts Docker Swarm ports to VCN-internal CIDR (`10.0.0.0/16`); removes port 3000 from the security list (dashboard access via SSH tunnel only); disables IMDSv1; enables Vulnerability Scanning agent on all instances; installs `ufw-docker` to prevent Docker from bypassing UFW rules
- **Multi-key SSH**: Change `ssh_authorized_keys` from `string` to `list(string)` to support multiple client keypairs
- **2 × (2 OCPU, 12 GB) layout**: Default to two A1.Flex instances at 2 OCPU / 12 GB each — exactly the OCI Always Free ceiling of 4 OCPU + 24 GB RAM
- **Ubuntu 24.04 provisioning fixes**: Handle apt lock race on first boot (disable `unattended-upgrades`, wait with `fuser` loop); pre-install Docker before the Dokploy installer runs; install `iptables-persistent` and `ufw` explicitly; use absolute path `/usr/sbin/ufw` (cloud-init runs with a restricted PATH)
- **Tooling**: Add `.tflint.hcl` config with official Terraform ruleset plugin; pin provider and OpenTofu version constraints (`required_version = ">= 1.5"` for OCI Resource Manager compatibility)
- **tfvars template**: Add `terraform.tfvars.example` to guide configuration

## Test plan

- [x] Run `tofu init` — providers download cleanly
- [x] Run `tflint --init && tflint` — no issues
- [x] Run `tofu validate` — succeeds
- [x] Deploy to OCI Always Free tier and confirm:
  - [x] SSH access works as `ubuntu@<ip>` with each authorised key
  - [x] Root SSH login is rejected
  - [x] Dokploy dashboard accessible via SSH tunnel (`ssh -L 3000:localhost:3000 ubuntu@<ip>`)
  - [x] Port 3000 not reachable directly from the internet
  - [x] Docker Swarm ports not reachable from outside the VCN
  - [x] Dokploy installation completes successfully (`Congratulations, Dokploy is installed\!`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)