### PR TITLE
introduced reserved ips

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,16 @@ After setting up the main Dokploy instance, you can expand your cluster by addin
 
 See more info about configuring your cluster on the [Dokploy Cluster Docs](https://docs.dokploy.com/docs/core/cluster).
 
+### Updating the server IP in Dokploy (e.g. after switching to reserved IP)
+
+If you change the instance’s public IP (for example from ephemeral to reserved), let Dokploy know about it:
+
+1. In the Dokploy dashboard, go to **Servers**.
+2. Click the server whose IP changed.
+3. Use **Update server IP** and the “set current public IP” control (double arrows) to set the server’s IP to the new public address.
+
+Note: **Reserved** Static IP does not change unless you release it. It stays in your account until you delete it.
+
 ## Project Structure
 
 -   `bin/`: Contains bash scripts for setting up Dokploy on both the main instance and the worker instances.
@@ -72,6 +82,7 @@ See more info about configuring your cluster on the [Dokploy Cluster Docs](https
 -   `main.tf`: Core Terraform configuration file that defines the infrastructure for Dokploy's main and worker instances.
 -   `network.tf`: Configuration for setting up the required OCI networking resources (VCNs, subnets, security lists, etc.).
 -   `output.tf`: Specifies the output variables such as the IP addresses for the dashboard and worker nodes.
+-   `reserved_ips.tf`: Optional reserved (static) public IPs for the main and worker instances when `use_reserved_public_ip` is enabled (see [Reserved public IPs](#reserved-static-public-ips)).
 -   `providers.tf`: Declares the required cloud providers and versions, particularly for Oracle Cloud Infrastructure.
 -   `README.md`: This file, providing instructions on deployment and usage.
 -   `variables.tf`: Defines input variables used in the project, including compartment ID, SSH keys, instance shape, and more.
@@ -88,3 +99,4 @@ Below are the key variables for deployment which are defined in `variables.tf`:
 -   `instance_shape`: Instance shape (e.g., VM.Standard.E2.1.Micro) used for deployment.
 -   `memory_in_gbs`: Memory size (GB) per instance.
 -   `ocpus`: Number of OCPUs per instance.
+-   `use_reserved_public_ip`: If `true`, assign reserved (static) public IPs to the main and worker instances instead of ephemeral IPs. Default is `false`. See [Reserved (static) public IPs](#reserved-static-public-ips).

--- a/main.tf
+++ b/main.tf
@@ -17,7 +17,7 @@ resource "oci_core_instance" "dokploy_main" {
     subnet_id                 = oci_core_subnet.dokploy_subnet.id
     assign_ipv6ip             = false
     assign_private_dns_record = true
-    assign_public_ip          = true
+    assign_public_ip          = !var.use_reserved_public_ip
   }
 
   availability_config {
@@ -105,7 +105,7 @@ resource "oci_core_instance" "dokploy_worker" {
     subnet_id                 = oci_core_subnet.dokploy_subnet.id
     assign_ipv6ip             = false
     assign_private_dns_record = true
-    assign_public_ip          = true
+    assign_public_ip          = !var.use_reserved_public_ip
   }
 
   availability_config {

--- a/output.tf
+++ b/output.tf
@@ -1,7 +1,7 @@
 output "dokploy_dashboard" {
-  value = "http://${oci_core_instance.dokploy_main.public_ip}:3000/ (wait 3-5 minutes to finish Dokploy installation)"
+  value = "http://${var.use_reserved_public_ip ? oci_core_public_ip.main[0].ip_address : oci_core_instance.dokploy_main.public_ip}:3000/ (wait 3-5 minutes to finish Dokploy installation)"
 }
 
 output "dokploy_worker_ips" {
-  value = [for instance in oci_core_instance.dokploy_worker : "${instance.public_ip} (use it to add the server in Dokploy Dashboard)"]
+  value = var.use_reserved_public_ip ? [for i in range(var.num_worker_instances) : "${oci_core_public_ip.worker[i].ip_address} (use it to add the server in Dokploy Dashboard)"] : [for instance in oci_core_instance.dokploy_worker : "${instance.public_ip} (use it to add the server in Dokploy Dashboard)"]
 }

--- a/reserved_ips.tf
+++ b/reserved_ips.tf
@@ -1,0 +1,41 @@
+# Reserved (static) public IPs for instances when use_reserved_public_ip = true.
+# OCI does not support attaching a reserved IP at instance create time in the API,
+# so we create instances without a public IP then attach reserved IPs to their primary private IP.
+
+# --- Main instance: get primary VNIC and its private IP ---
+data "oci_core_vnic_attachments" "main" {
+  compartment_id = var.compartment_id
+  instance_id    = oci_core_instance.dokploy_main.id
+}
+
+data "oci_core_private_ips" "main_private_ips" {
+  vnic_id = data.oci_core_vnic_attachments.main.vnic_attachments[0].vnic_id
+}
+
+resource "oci_core_public_ip" "main" {
+  count          = var.use_reserved_public_ip ? 1 : 0
+  compartment_id = var.compartment_id
+  display_name   = "dokploy-main-${random_string.resource_code.result}-reserved-ip"
+  lifetime       = "RESERVED"
+  private_ip_id  = data.oci_core_private_ips.main_private_ips.private_ips[0].id
+}
+
+# --- Worker instances: same for each worker ---
+data "oci_core_vnic_attachments" "worker" {
+  count          = var.num_worker_instances
+  compartment_id = var.compartment_id
+  instance_id    = oci_core_instance.dokploy_worker[count.index].id
+}
+
+data "oci_core_private_ips" "worker_private_ips" {
+  count   = var.num_worker_instances
+  vnic_id = data.oci_core_vnic_attachments.worker[count.index].vnic_attachments[0].vnic_id
+}
+
+resource "oci_core_public_ip" "worker" {
+  count          = var.use_reserved_public_ip ? var.num_worker_instances : 0
+  compartment_id = var.compartment_id
+  display_name   = "dokploy-worker-${count.index + 1}-${random_string.resource_code.result}-reserved-ip"
+  lifetime       = "RESERVED"
+  private_ip_id  = data.oci_core_private_ips.worker_private_ips[count.index].private_ips[0].id
+}

--- a/variables.tf
+++ b/variables.tf
@@ -46,3 +46,9 @@ variable "ocpus" {
   type        = string
   default     = "1" # OCI Free
 }
+
+variable "use_reserved_public_ip" {
+  description = "If true, assign reserved (static) public IPs to instances instead of ephemeral. Reserved IPs persist if the instance is recreated."
+  type        = bool
+  default     = false
+}


### PR DESCRIPTION
This change is to introduce optional usage of reserved IPs (by default false to preserve previous behaviour).
Why: using reserved IPs makes it easier to maintain the server, as in case of stack destroy and then redeploy of the Dockploy cluster the same reserved IPs (still available in the account) could be attached to the nodes, avoiding the need to update IPs in Dns records

## Reserved (static) public IPs

### Ephemeral vs reserved IPs in OCI

| Type        | Behaviour |
|------------|-----------|
| **Ephemeral** | Temporary IP tied to the instance. If you **stop and then restart** the instance, it will usually get a new public IP. A simple **reboot** of the OS often keeps the same IP. In the OCI console: *Instances → NIC → View details → Public IP address* shows e.g. `130.61.84.1 (Ephemeral)`. |
| **Reserved**  | Static IP that does not change unless you release it. It stays in your account until you delete it. |

### Cost and limits in OCI
(as of my research in February)
- **No cost**: OCI does not charge for creating, reserving, or assigning Reserved Public IPs.
- **Free to reserve**: Up to **50 Reserved Public IPs per region** at no charge.
- **Unused IPs**: Reserved IPs that are not assigned to an instance are not billed.
- **Limits**: Up to 50 reserved public IPs per region per tenancy; up to 32 per VNIC.

### How it works with this Terraform project

OCI does not let you attach a reserved public IP in `create_vnic_details`. The flow is:

1. Create the instance **without** an ephemeral public IP (`assign_public_ip = false`).
2. Create one or more reserved public IPs with `oci_core_public_ip` and `lifetime = "RESERVED"`.
3. Attach each reserved public IP to the instance’s **primary private IP** via the `private_ip_id` argument (after looking up the primary VNIC’s private IP).

What this repo adds when using reserved IPs:

- **Variable** `use_reserved_public_ip` in `variables.tf` (default `false`, so behaviour is unchanged if you don’t set it).
- **main.tf**: `assign_public_ip` is set to `!var.use_reserved_public_ip` for both the main and worker instances.
- **reserved_ips.tf**: Uses `oci_core_vnic_attachments` and `oci_core_private_ips` to get the primary private IP for the main instance and each worker; defines `oci_core_public_ip.main` and `oci_core_public_ip.worker` with `lifetime = "RESERVED"` and the corresponding `private_ip_id`.
- **output.tf**: When `use_reserved_public_ip` is true, outputs use the reserved public IP(s); otherwise they use the instance `public_ip`.

### How to use reserved public IPs

Set the variable to `true`, for example in `terraform.tfvars` or `terraform.tfvars.json`:

```hcl
use_reserved_public_ip = true
```

or on the command line:

```bash
terraform apply -var="use_reserved_public_ip=true"
```

Then run `terraform plan` and `terraform apply` as usual. With `use_reserved_public_ip = true`, instances are created without an ephemeral public IP and reserved public IPs are created and attached to their primary private IPs. Those IPs remain reserved if you destroy and recreate the instances; you can later reassign them to other private IPs or leave them unassigned.

For existing stacks, if you change the instance public IP (e.g. after enabling reserved IPs), besides updating dns records update also the server IP in Dokploy as described in the committed Readme.